### PR TITLE
[engine.graphic] Improve material factorization on glTF meshes.

### DIFF
--- a/todo.md
+++ b/todo.md
@@ -9,10 +9,10 @@
 - Extract model textures out of materials to factorize bitmaps
 - Support animated models and load animations from glTF files
 - Implement feature-level attributes (e.g. no texture) in forward lighting renderer [forward-lighting-feature]
-- Factorize materials when merging meshes [material-factorize]
 
 ## Done
 
+- Factorize materials when merging meshes [material-factorize]
 - Improve typing of application configuration [application-configuration-typing]
 - Split scene update and draw to perform batch sorting only on change
 - Fix sRGB/RGB not applied in deferred shading


### PR DESCRIPTION
Channel-mapped textures (metalnessMap, roughnessMap) still prevent material factorization to apply properly and cause always-different materials.