### PR TITLE
[engine.graphic] Extract dedicated interface for particle emitter.

### DIFF
--- a/src/engine/graphic/renderer.ts
+++ b/src/engine/graphic/renderer.ts
@@ -27,12 +27,6 @@ import {
   ForwardLightingSubject,
 } from "./renderer/forward-lighting";
 import {
-  ParticleHandle,
-  ParticleRenderer,
-  ParticleScene,
-  createParticleRenderer,
-} from "./renderer/particle";
-import {
   SoftwareDrawMode,
   SoftwareRenderer,
   SoftwareScene,
@@ -56,9 +50,6 @@ export {
   type ForwardLightingRenderer,
   type ForwardLightingScene,
   type ForwardLightingSubject,
-  type ParticleHandle,
-  type ParticleRenderer,
-  type ParticleScene,
   type Renderer,
   type SoftwareRenderer,
   type SoftwareScene,
@@ -70,6 +61,5 @@ export {
   createDeferredLightingRenderer,
   createDeferredShadingRenderer,
   createForwardLightingRenderer,
-  createParticleRenderer,
   createSoftwareRenderer,
 };


### PR DESCRIPTION
This implementation made renderer too specific (handle exposing an "emit" function, renderer having an "update" method) ; move to its own definition.