### PR TITLE
[engine.graphic] Add `autoReleaseShader` option to `GlMeshRenderer`.

### DIFF
--- a/src/engine/graphic/renderer/deferred-lighting.ts
+++ b/src/engine/graphic/renderer/deferred-lighting.ts
@@ -828,7 +828,8 @@ const createDeferredLightingRenderer = (
   const geometryBinder = createGeometryBinder(runtime, configuration);
   const geometryRenderer = createGlMeshRenderer(
     GlMeshRendererMode.Triangle,
-    geometryBinder
+    geometryBinder,
+    {}
   );
   const lightBuffer = lightTarget.setupColorTexture(
     GlTextureFormat.RGBA8,
@@ -837,7 +838,8 @@ const createDeferredLightingRenderer = (
   const materialBinder = createMaterialBinder(runtime, configuration);
   const materialRenderer = createGlMeshRenderer(
     GlMeshRendererMode.Triangle,
-    materialBinder
+    materialBinder,
+    {}
   );
   const pointLightBillboard = createPointLightBillboard(gl);
   const pointLightPainter = loadPointLightPainter(runtime, configuration);

--- a/src/engine/graphic/renderer/deferred-shading.ts
+++ b/src/engine/graphic/renderer/deferred-shading.ts
@@ -792,7 +792,8 @@ const createDeferredShadingRenderer = (
   const ambientLightBinder = createAmbientLightBinder(runtime, configuration);
   const ambientLightRenderer = createGlMeshRenderer(
     GlMeshRendererMode.Triangle,
-    ambientLightBinder
+    ambientLightBinder,
+    {}
   );
   ambientLightRenderer.append(quad.mesh);
   const depthBuffer = geometryTarget.setupDepthTexture(
@@ -816,7 +817,8 @@ const createDeferredShadingRenderer = (
   const geometryBinder = createGeometryBinder(runtime, configuration);
   const geometryRenderer = createGlMeshRenderer(
     GlMeshRendererMode.Triangle,
-    geometryBinder
+    geometryBinder,
+    {}
   );
   const pointLightBillboard = createPointLightBillboard(gl);
   const normalAndSpecularBuffer = geometryTarget.setupColorTexture(

--- a/src/engine/graphic/renderer/forward-lighting.ts
+++ b/src/engine/graphic/renderer/forward-lighting.ts
@@ -856,7 +856,8 @@ const createForwardLightingRenderer = (
   const lightBinder = createLightBinder(runtime, directive, configuration);
   const lightRenderer = createGlMeshRenderer(
     GlMeshRendererMode.Triangle,
-    lightBinder
+    lightBinder,
+    {}
   );
 
   const directionalShadowBuffers = directionalShadowTargets.map((target) =>
@@ -865,7 +866,8 @@ const createForwardLightingRenderer = (
   const directionalShadowBinder = createDirectionalShadowBinder(runtime);
   const directionalShadowRenderer = createGlMeshRenderer(
     GlMeshRendererMode.Triangle,
-    directionalShadowBinder
+    directionalShadowBinder,
+    {}
   );
   const directionalShadowProjection = Matrix4.fromIdentity([
     "setFromOrthographic",


### PR DESCRIPTION
This option, disabled by default, is a new prerequisite for `GlMeshRenderer` automatically releasing shaders when last use its dropped. This behavior was responsible for too many shader creations when playing with small number of subjects.